### PR TITLE
Updated instructions for clarity

### DIFF
--- a/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
+++ b/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
@@ -592,7 +592,7 @@ Call Park is disabled by default. Our organization would like the option to use 
 
 3. Select the **Global (org wide default)** policy.
 
-4. Switch **Allow call park** to **On**.
+4. Switch **Call park** to **On**.
 
 5. Select **Save**.
 
@@ -752,7 +752,7 @@ Now Isaiah has a calling plan and phone number and we will perform a test call t
 
 11. If you are prompted with the Teams welcome information:
 
-	- Bring your team together**,** select **Next**.
+	- Bring your team together, select **Next**.
 
 	- Chat 1:1 and with groups, select **Next**.
 
@@ -828,7 +828,7 @@ In this task you will order a new Dedicated conference bridge toll number. This 
 
 7. For **Number Type**, select **Dedicated conference bridge (Toll)**.
 
-8. The Quantity field will now appear, enter 1.
+8. For **Operator**, select **Microsoft**, the Quantity field will now appear, enter 1.
 
 9. For **Search for new numbers** select **search by area code** and enter **920**.
 
@@ -886,7 +886,7 @@ In this task you will create a call queue. A call queue is a group of agents tha
 
 6. Enter **Sales CQ** as **Display name**
 
-7. **SalesCQ** as **Username,** leave domain as is**,** 
+7. **SalesCQ** as **Username,** leave domain as is. 
 
 8. **Resource account type** select **Call queue,** then select **Save**.
 
@@ -912,7 +912,7 @@ Now we will Create an Auto attendant and direct one of the options to send calls
 
 2. Under **Voice**, select **Auto Attendants** and select **Add**.
 
-3. Enter **Sales AA** for the name**,** 
+3. Enter **Sales AA** for the name,
 
 4. Time zone of **(UTC-08:00) Pacific Time (US…,** 
 
@@ -986,6 +986,8 @@ In this task you will enable conference mode that will then make it pass the cal
 
 3. Under **Call answering** select find **Conferencing mode,** toggle the setting to **On**. 
 
+4. Select **Save**
+
 You have successfully enabled conferencing mode for **Sales CQ** call queue.
 
 ### Task 5 - Set holiday modes within AA
@@ -996,7 +998,7 @@ In this task you will create the relevant holiday configuration. Holidays differ
 
 1. In the Microsoft Teams admin center, go to **Voice &gt; Holidays**.
 
-2. Select **New holiday**.
+2. Select **Add**.
 
 3. Enter a name for the holiday.
 
@@ -1024,7 +1026,7 @@ In this task you will obtain a free MP3 to the music on hold solution for the Sa
 
 2. Open Microsoft Edge open a new tab and browse to [https://onhold2go.co.uk/Free_Music_On_Hold.php](https://onhold2go.co.uk/Free_Music_On_Hold.php).
 
-3. Download **A New Life** by selecting the ellipses and then download.
+3. Download **A New Life** by selecting the ellipses and then download. After the download completes, extract the contents of the zip file.
 
 4. Close the tab and switch back to the Microsoft Teams admin center.
 


### PR DESCRIPTION
Exercise 7 Task 2 requires a Team that has been already set up.  Instructions will need to be added somewhere to create a Team named Contoso loves Teams to match the lab.  I would suggest this be done in Exercise 5 Task 3 when the Teams client is installed.

# Module: 00
## Lab/Demo: 2

Fixes # .

Changes proposed in this pull request:

- Updated instructions for clarity and removed erroneous ** from instructions.  
- Teams is caught in an update loop, had to use the web app to perform tasks.
- Exercise 7 Task 1 should be split into 2 tasks - Task 1 steps 1-15, Task 2 Steps 16 and forward.
- 
-
[MS720-Lab2EditsRequired.docx](https://github.com/MOC-Labs-Review/MS-720-Microsoft-Teams-Voice-Engineer/files/7914394/MS720-Lab2EditsRequired.docx)

-